### PR TITLE
Feature/gradle reintro build

### DIFF
--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -57,5 +57,4 @@ This plugin will use the `snapshotSuffix` in `gradle.properties` or `build.gradl
 
 ### Build After Version Bump Automatically
 
-This plugin will allow build to occur in-line for native apps versus libraries.  It
-will do so if `buildDuringRelease` in `gradle.properties` or `build.gradle` is configured.
+This plugin will run a release build to create release artifacts.

--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -55,9 +55,12 @@ describe('Gradle Plugin', () => {
       await hooks.version.promise(Auto.SEMVER.patch);
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
-        'updateVersion',
+        'release',
         '-Prelease.useAutomaticVersion=true',
-        `-Prelease.newVersion=1.0.1`
+        `-Prelease.newVersion=1.0.1`,
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
       ]);
     });
 
@@ -72,17 +75,17 @@ describe('Gradle Plugin', () => {
       await hooks.version.promise(Auto.SEMVER.major);
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
-        'updateVersion',
+        'release',
         '-Prelease.useAutomaticVersion=true',
-        `-Prelease.newVersion=2.0.0`
+        `-Prelease.newVersion=2.0.0`,
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
       ]);
     });
 
     test('should version release - major version - w/build', async () => {
-      const properties = `
-        version: 1.0.0
-        buildDuringRelease: true
-      `;
+      const properties = `version: 1.0.0`;
 
       mockProperties(properties);
       await hooks.beforeRun.promise({} as any);
@@ -100,7 +103,7 @@ describe('Gradle Plugin', () => {
         '-x preTagCommit',
         '-x commitNewVersion'
       ]);
-    }); 
+    });
 
     test('should version release - minor version', async () => {
       const properties = 'version: 1.1.0';
@@ -113,9 +116,12 @@ describe('Gradle Plugin', () => {
       await hooks.version.promise(Auto.SEMVER.minor);
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
-        'updateVersion',
+        'release',
         '-Prelease.useAutomaticVersion=true',
-        `-Prelease.newVersion=1.2.0`
+        `-Prelease.newVersion=1.2.0`,
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
       ]);
     });
 
@@ -130,9 +136,12 @@ describe('Gradle Plugin', () => {
       await hooks.version.promise(Auto.SEMVER.patch);
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
-        'updateVersion',
+        'release',
         '-Prelease.useAutomaticVersion=true',
-        `-Prelease.newVersion=1.0.0`
+        `-Prelease.newVersion=1.0.0`,
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
       ]);
     });
 
@@ -151,9 +160,12 @@ describe('Gradle Plugin', () => {
       await hooks.version.promise(Auto.SEMVER.patch);
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
-        'updateVersion',
+        'release',
         '-Prelease.useAutomaticVersion=true',
-        `-Prelease.newVersion=1.0.0`
+        `-Prelease.newVersion=1.0.0`,
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
       ]);
     });
   });
@@ -183,9 +195,12 @@ describe('Gradle Plugin - Custom Command', () => {
       await hooks.version.promise(Auto.SEMVER.patch);
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradlew'), [
-        'updateVersion',
+        'release',
         '-Prelease.useAutomaticVersion=true',
         `-Prelease.newVersion=1.0.1`,
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion',
         '-P prop=val'
       ]);
     });

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -19,7 +19,7 @@ const pluginOptions = t.partial({
   gradleCommand: t.string,
 
   /** A list of gradle command customizations to pass to gradle */
-  gradleOptions: t.array(t.string),
+  gradleOptions: t.array(t.string)
 });
 
 export type IGradleReleasePluginPluginOptions = t.TypeOf<typeof pluginOptions>;
@@ -33,9 +33,6 @@ export interface IGradleProperties {
 
   /** publish task - exists if maven-publish plugin is installed */
   publish?: string;
-
-  /** buildDuringRelease - if set to true, then build the project as part release (def. for gradle release plugin) */
-  buildDuringRelease?: boolean;
 }
 
 /**
@@ -85,7 +82,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
 
   /** cached properties */
   private properties: IGradleProperties = {};
-  
+
   /** should this release be a snapshot release */
   private snapshotRelease = false;
 
@@ -100,8 +97,12 @@ export default class GradleReleasePluginPlugin implements IPlugin {
   }
 
   /** update gradle version and commit */
-  private updateGradleVersion = async (version: string, commitMsg?: string) => {
-    if (this.properties.buildDuringRelease) {
+  private updateGradleVersion = async (
+    version: string,
+    commitMsg?: string,
+    buildFlag: boolean = true
+  ) => {
+    if (buildFlag) {
       // don't create release, tag, or commit since auto will do this
       await execPromise(this.options.gradleCommand, [
         'release',
@@ -228,7 +229,8 @@ export default class GradleReleasePluginPlugin implements IPlugin {
 
       await this.updateGradleVersion(
         newVersion,
-        `prepare snapshot version: ${newVersion} [skip ci]`
+        `prepare snapshot version: ${newVersion} [skip ci]`,
+        false
       );
 
       await execPromise('git', [


### PR DESCRIPTION
# What Changed
Always build release and ensure that we don't build snapshot versions

# Why
Because there isn't a need to configure this

Todo:

- [x] Add tests
- [x] Add docs
